### PR TITLE
Adding support for 3 extended consent types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ With **Google Consent Mode V2**, you can set the following purposes:
 - **ad_storage**: Manages the consent for advertising cookies.
 - **ad_user_data**: Defines consent for user data related to advertising.
 - **ad_personalization**: Configures consent for personalized advertising cookies.
+- **functionality_storage**: Enables storage that supports site functionality (for example, language settings).
+- **personalization_storage**: Enables storage related to personalization (for example, content or video recommendations).
+- **security_storage**: Enables storage related to security (for example, authentication and fraud prevention).
 
 You can define multiple purposes in the granted and denied fields in this format:
-`analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`.mnb.
+`analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`, `functionality_storage`, `personalization_storage`, `security_storage`.
 
 ###  Region Selection
 You have the option to select the **region** where you want to apply the consent settings. If left blank, it will apply to all regions by default.

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -178,7 +178,7 @@ ___TEMPLATE_PARAMETERS___
             "param": {
               "type": "SELECT",
               "name": "analytics_storage",
-              "displayName": "Analytics storage",
+              "displayName": "Analytics",
               "selectItems": [
                 {
                   "value": "denied",
@@ -190,7 +190,8 @@ ___TEMPLATE_PARAMETERS___
                 }
               ],
               "simpleValueType": true,
-              "defaultValue": "denied"
+              "defaultValue": "denied",
+              "help": "analytics_storage: Enables storage, such as cookies (web) or device identifiers (apps), related to analytics, for example, visit duration."
             },
             "isUnique": false
           },
@@ -198,7 +199,7 @@ ___TEMPLATE_PARAMETERS___
             "param": {
               "type": "SELECT",
               "name": "ad_storage",
-              "displayName": "Ad storage",
+              "displayName": "Ads",
               "selectItems": [
                 {
                   "value": "denied",
@@ -210,7 +211,8 @@ ___TEMPLATE_PARAMETERS___
                 }
               ],
               "simpleValueType": true,
-              "defaultValue": "denied"
+              "defaultValue": "denied",
+              "help": "ad_storage: Enables storage, such as cookies (web) or device identifiers (apps), related to advertising."
             },
             "isUnique": false
           },
@@ -218,7 +220,7 @@ ___TEMPLATE_PARAMETERS___
             "param": {
               "type": "SELECT",
               "name": "ad_user_data",
-              "displayName": "Ad user data",
+              "displayName": "Ad user",
               "selectItems": [
                 {
                   "value": "denied",
@@ -230,7 +232,8 @@ ___TEMPLATE_PARAMETERS___
                 }
               ],
               "simpleValueType": true,
-              "defaultValue": "denied"
+              "defaultValue": "denied",
+              "help": "ad_user_data: Sets consent for sending user data to Google for online advertising purposes."
             },
             "isUnique": false
           },
@@ -238,7 +241,7 @@ ___TEMPLATE_PARAMETERS___
             "param": {
               "type": "SELECT",
               "name": "ad_personalization",
-              "displayName": "Ad personalization",
+              "displayName": "Ad perso.",
               "selectItems": [
                 {
                   "value": "denied",
@@ -250,7 +253,71 @@ ___TEMPLATE_PARAMETERS___
                 }
               ],
               "simpleValueType": true,
-              "defaultValue": "denied"
+              "defaultValue": "denied",
+              "help": "ad_personalization: Sets consent for personalized advertising."
+            },
+            "isUnique": false
+          },
+          {
+            "param": {
+              "type": "SELECT",
+              "name": "functionality_storage",
+              "displayName": "Functionality",
+              "selectItems": [
+                {
+                  "value": "denied",
+                  "displayValue": "Denied"
+                },
+                {
+                  "value": "granted",
+                  "displayValue": "Granted"
+                }
+              ],
+              "simpleValueType": true,
+              "defaultValue": "denied",
+              "help": "functionality_storage: Enables storage that supports the functionality of the website or app, for example, language settings."
+            },
+            "isUnique": false
+          },
+          {
+            "param": {
+              "type": "SELECT",
+              "name": "personalization_storage",
+              "displayName": "Perso.",
+              "selectItems": [
+                {
+                  "value": "denied",
+                  "displayValue": "Denied"
+                },
+                {
+                  "value": "granted",
+                  "displayValue": "Granted"
+                }
+              ],
+              "simpleValueType": true,
+              "defaultValue": "denied",
+              "help": "personalization_storage: Enables storage related to personalization, for example, video recommendations."
+            },
+            "isUnique": false
+          },
+          {
+            "param": {
+              "type": "SELECT",
+              "name": "security_storage",
+              "displayName": "Security",
+              "selectItems": [
+                {
+                  "value": "denied",
+                  "displayValue": "Denied"
+                },
+                {
+                  "value": "granted",
+                  "displayValue": "Granted"
+                }
+              ],
+              "simpleValueType": true,
+              "defaultValue": "denied",
+              "help": "security_storage: Enables storage related to security such as authentication functionality, fraud prevention, and other user protection."
             },
             "isUnique": false
           }
@@ -727,6 +794,99 @@ ___WEB_PERMISSIONS___
                   {
                     "type": 1,
                     "string": "ad_personalization"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "functionality_storage"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "personalization_storage"
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  },
+                  {
+                    "type": 8,
+                    "boolean": true
+                  }
+                ]
+              },
+              {
+                "type": 3,
+                "mapKey": [
+                  {
+                    "type": 1,
+                    "string": "consentType"
+                  },
+                  {
+                    "type": 1,
+                    "string": "read"
+                  },
+                  {
+                    "type": 1,
+                    "string": "write"
+                  }
+                ],
+                "mapValue": [
+                  {
+                    "type": 1,
+                    "string": "security_storage"
                   },
                   {
                     "type": 8,


### PR DESCRIPTION
- Adding support for functionality_storage, personalization_storage and security_storage
- Truncating column names for better formatting of the table
- Adding help text for all 7 consent types



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for three new Google Consent Mode v2 types: `functionality_storage`, `personalization_storage`, and `security_storage`. Also adds help text for all seven consent types and shortens labels for a cleaner table.

- **New Features**
  - Added selects for `functionality_storage`, `personalization_storage`, `security_storage` with read/write web permissions; default `denied`.
  - Added help text for `analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`, and the new types.
  - Shortened display names (e.g., “Analytics”, “Ads”, “Ad user”, “Ad perso.”, “Perso.”, “Functionality”, “Security”) to improve table layout.
  - Updated README to list the new types and corrected the example.

<sup>Written for commit 6f990b84cb4452405d8b4f5c08be1793152584d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

