### PR TITLE
Feature/early update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,84 @@
-# Axeptio CMP Google Tag Manager Template
+<h1>
+  <img src="https://axeptio.imgix.net/2024/07/e444a7b2-ea3d-4471-a91c-6be23e0c3cbb.png" alt="Descrizione immagine" width="80" style="vertical-align: middle; margin-right: 10px;" />
+  Axeptio CMP Google Tag Manager Template
+</h1>
 
-![Axeptio Logo](/assets/logo-axeptio.svg)
-https://axept.io
+This template allows you to easily integrate the **Axeptio SDK** into your **Google Tag Manager (GTM)** container for managing user consent. By leveraging this tag, you can ensure GDPR and ePrivacy compliance while providing a seamless user experience.
 
-This tag allows you to add the Axeptio SDK to your Google Tag Manager container.
+<br>
 
-You configure:
-- Your Project ID
-- Your CookieVersion
+## 📑 Table of Contents
 
-By using variables, you can dynamically set the CookieVersion based on a dataLayer variable, the Hostname, or other parameters.
+1. [Key Configuration Options](#key-configuration-options)
+   - [Project ID and Cookie Version](#project-id-and-cookie-version)
+   - [Axeptio Settings](#axeptio-settings)
+   - [Consent Mode Configuration](#consent-mode-configuration)
+   - [Region Selection](#region-selection)
+2. [Installation Guide](#installation-guide)
+   - [Step 1: Add the Template from the Gallery](#step-1-add-the-template-from-the-gallery)
+   - [Step 2: Add the Axeptio Tag](#step-2-add-the-axeptio-tag)
+   - [Step 3: Add the Trigger](#step-3-add-the-trigger)
+   - [Step 4: Publish the Container](#step-4-publish-the-container)
+3. [Support](#support)
 
-## Axeptio Settings
+<br><br>
 
-You can customize the Axeptio settings:
+## Key Configuration Options
 
-- Cookie lifespan
-- Cookie domain
-- DataLayer name
-- Transport URL (Server Side Tracking)
+### Project ID and Cookie Version
+- **Project ID**: The unique identifier for your Axeptio project.
+- **Cookie Version´**: The version of the cookies being used in your website or application. This can be dynamically set via a **dataLayer** variable, **Hostname**, or any other parameters you define.
 
-## Consent Mode V2
+### Axeptio Settings
+You can configure several settings within the **Axeptio** template to align with your specific use case:
+- **Cookie Lifespan**: Defines the duration of time a cookie remains active after the user consents.
+- **Cookie Domain**: Specifies the domain on which the cookie will be valid.
+- **DataLayer Name**: Customize the dataLayer name if you are using a custom dataLayer object.
+- **Transport URL (Server-Side Tracking)**: Configure the transport URL to send consent data to a server-side endpoint for tracking purposes.
+- **Consent Mode V2**: The template supports Google Consent Mode V2, which allows you to set consent states for different purposes, such as analytics, ads, etc.
 
-The Axeptio CMP template allows you to configure Google Consent Mode V2 with the default value.
+### Consent Mode Configuration
+With **Google Consent Mode V2**, you can set the following purposes:
+- **analytics_storage**: Controls the consent for analytics-related cookies.
+- **ad_storage**: Manages the consent for advertising cookies.
+- **ad_user_data**: Defines consent for user data related to advertising.
+- **ad_personalization**: Configures consent for personalized advertising cookies.
 
-You can choose the region or leave it blank to set it to ALL.
+You can define multiple purposes in the granted and denied fields in this format:
+`analytics_storage`, `ad_storage`, `ad_user_data`, `ad_personalization`.mnb.
 
-In the granted and denied fields, add the purposes:
+###  Region Selection
+You have the option to select the **region** where you want to apply the consent settings. If left blank, it will apply to all regions by default.
 
-- analytics_storage
-- ad_storage
-- ad_user_data
-- ad_personalization
+<br><br>
+## 🚀Installation Guide
 
-Example : analytics_storage, ad_storage, ad_user_data, ad_personalization
+### Step 1: Add the Template from the Gallery
+1. In your **Google Tag Manager** (GTM) container, go to the **Templates** section.
+2. Search for the **Axeptio GTM Public Template** in the gallery and add it to your container.
 
-## Axeptio Setup
+### Step 2: Add the Axeptio Tag
+1. In the **Tags** section of your GTM container, create a new tag.
+2. Select the **Axeptio tag** template you just imported.
+3. Configure the following parameters:
+- **Project ID**: Enter your unique Axeptio project ID.
+- **Cookie Version**: Define the Cookie Version for your setup (you can use a dataLayer variable to dynamically adjust this).
+- **Axeptio Settings**: Customize additional settings such as Cookie Lifespan, Cookie Domain, and Transport URL if needed.
 
-- Add the template from the gallery: [Axeptio GTM Public Template](https://tagmanager.google.com/gallery/#/owners/axeptio/templates/axeptio-gtm-public-template)
-- In the Tags section, add the Axeptio tag
-- Configure your projectId and CookieVersion
-- Configure the AxeptioSettings
-- Add the trigger: Consent Initialization
-- Publish your project, the widget is installed.
+### Step 3: Add the Trigger
+Set the **trigger** for the tag. The recommended trigger for this tag is _**Consent Initialization**, which ensures the tag is fired early in the user’s interaction flow.
 
-## Support
+### Step 4: Publish the Container
+Once all configurations are set, **publish** your GTM container. The **Axeptio widget** will now be installed and ready for use.
 
-If you encounter any issues during the installation of our Google Tag Manager tag, you can send an email to: help@axeptio.eu
+<br><br> 
 
-- [English support](https://support.axeptio.eu/hc/en-gb)
+## 🛠Support
+If you encounter any issues or need assistance with the Axeptio GTM tag, please reach out to our support team: help@axeptio.eu
 
-- [French support](https://support.axeptio.eu/hc/fr)
+- [English Support](https://support.axeptio.eu/hc/en-gb)
 
+- [French Support](https://support.axeptio.eu/hc/en-gb)
+
+<br><br> 
+This version improves the overall flow of the document, providing clearer, step-by-step instructions for implementing the Axeptio Client template in **Google Tag Manager**, while also adding more technical details for advanced configurations. Let me know if you need further tweaks!

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.axept.io/"
 documentation: "https://support.axeptio.eu/en/"
 versions:
   # Latest version
+  - sha: 0bb07da989ff1745af7c8982f765536ef5201d76
+    changeNotes: added additional Axeptio settings table
+  # Older versions
   - sha: bfa04e5dcc4df419ab4ffec2e4550e2c0a584b5c
     changeNotes: changed cookie duration default value to 180 days
-  # Older versions
   - sha: 050d2151c695c5082189a2e77c7a448052c93d0b
     changeNotes: added platform tag
   - sha: b53976f3f3dca5128cd38c9a6fefd10611ef7d2c

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.axept.io/"
 documentation: "https://support.axeptio.eu/hc/en-gb"
 versions:
   # Latest version
+  - sha: 050d2151c695c5082189a2e77c7a448052c93d0b
+    changeNotes: added platform tag
+  # Older versions
   - sha: b53976f3f3dca5128cd38c9a6fefd10611ef7d2c
     changeNotes: default values for Consent Mode v2 when unset
-  # Older versions
   - sha: 05d47919fb3ee27a82b89fb205b3ee4ee20ef6e1
     changeNotes: changed how Consent Mode v2 Default values are set
   - sha: e098afab175675b8a3ad2f7650d464c2193d3f49

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,11 @@ homepage: "https://www.axept.io/"
 documentation: "https://support.axeptio.eu/hc/en-gb"
 versions:
   # Latest version
+  - sha: b53976f3f3dca5128cd38c9a6fefd10611ef7d2c
+    changeNotes: default values for Consent Mode v2 when unset
+  # Older versions
   - sha: 05d47919fb3ee27a82b89fb205b3ee4ee20ef6e1
     changeNotes: changed how Consent Mode v2 Default values are set
-  # Older versions
   - sha: e098afab175675b8a3ad2f7650d464c2193d3f49
     changeNotes: renamed api Url for server-side
   - sha: eec2376aa80849314a82f4fcd0bb8eafcaf22e2f

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 homepage: "https://www.axept.io/"
-documentation: "https://support.axeptio.eu/hc/en-gb"
+documentation: "https://support.axeptio.eu/en/"
 versions:
   # Latest version
+  - sha: bfa04e5dcc4df419ab4ffec2e4550e2c0a584b5c
+    changeNotes: changed cookie duration default value to 180 days
+  # Older versions
   - sha: 050d2151c695c5082189a2e77c7a448052c93d0b
     changeNotes: added platform tag
-  # Older versions
   - sha: b53976f3f3dca5128cd38c9a6fefd10611ef7d2c
     changeNotes: default values for Consent Mode v2 when unset
   - sha: 05d47919fb3ee27a82b89fb205b3ee4ee20ef6e1

--- a/template.tpl
+++ b/template.tpl
@@ -292,6 +292,38 @@ ___TEMPLATE_PARAMETERS___
         "help": "When a user lands on your website after clicking an ad, information about the ad may be appended to your landing page URLs as a query parameter. In order to improve conversion accuracy, this information is usually stored in first-party cookies on your domain.  However, if ad_storage is set to denied, this information will not be stored locally. To improve ad click measurement quality when ad_storage is denied, you can optionally elect to pass information about ad clicks through URL parameters across pages using URL passthrough.  Similarly, if analytics_storage is set to denied, URL passthrough can be used to send event and session-based analytics (including conversions) without cookies across pages."
       }
     ]
+  },
+  {
+    "type": "GROUP",
+    "name": "additionalSettingsGroup",
+    "displayName": "Additional Axeptio Settings",
+    "groupStyle": "ZIPPY_CLOSED",
+    "subParams": [
+      {
+        "type": "SIMPLE_TABLE",
+        "name": "axeptioAdditionalSettings",
+        "displayName": "Additional Axeptio Settings",
+        "simpleTableColumns": [
+          {
+            "type": "TEXT",
+            "name": "key",
+            "displayName": "Key",
+            "simpleValueType": true,
+            "help": "Name of the Axeptio setting to override or extend.",
+            "isUnique": true
+          },
+          {
+            "type": "TEXT",
+            "name": "value",
+            "displayName": "Value",
+            "simpleValueType": true,
+            "help": "Value assigned to the setting.",
+            "isUnique": false
+          }
+        ],
+        "help": "Here you can add additional settings from our SDK. You can find the full documentationt here : https://support.axeptio.eu/en/articles/274040-advanced-options-and-mode-axeptiosettings"
+      }
+    ]
   }
 ]
 
@@ -351,20 +383,33 @@ main(data);
 
 }
 
-setInWindow('axeptioSettings', 
-{clientId: data.id,
-cookiesVersion: data.cookiesVersion,
-dataLayerName: data.dataLayerName,
-userCookiesDuration: makeNumber(data.cookiesDuration),
-userCookiesDomain: data.cookiesDomain,
-userCookiesSecure: data.cookiesSecure,
-postConsentUrl: data.postConsentUrl,
-triggerGTMEvents: data.triggerGTMEvents,
-platform: 'tms-gtm',
-},
-true);
+const axeptioSettings = {
+  clientId: data.id,
+  cookiesVersion: data.cookiesVersion,
+  dataLayerName: data.dataLayerName,
+  userCookiesDuration: makeNumber(data.cookiesDuration),
+  userCookiesDomain: data.cookiesDomain,
+  userCookiesSecure: data.cookiesSecure,
+  postConsentUrl: data.postConsentUrl,
+  triggerGTMEvents: data.triggerGTMEvents,
+  platform: 'tms-gtm'
+};
 
-
+const additionalSettings = data.axeptioAdditionalSettings || data.additionalSettings;
+if (additionalSettings && typeof additionalSettings.length === 'number') {
+  for (let index = 0; index < additionalSettings.length; index += 1) {
+    const entry = additionalSettings[index];
+    if (!entry || typeof entry !== 'object') {
+      continue;
+    }
+    const key = typeof entry.key === 'string' ? entry.key.trim() : entry.key;
+    if (!key) {
+      continue;
+    }
+    axeptioSettings[key] = entry.value;
+  }
+}
+setInWindow('axeptioSettings', axeptioSettings, true);
 
 if (queryPermission('inject_script', 'https://static.axept.io/sdk.js')) {
   injectScript('https://static.axept.io/sdk.js', data.gtmOnSuccess, data.gtmOnFailure);

--- a/template.tpl
+++ b/template.tpl
@@ -360,6 +360,7 @@ userCookiesDomain: data.cookiesDomain,
 userCookiesSecure: data.cookiesSecure,
 postConsentUrl: data.postConsentUrl,
 triggerGTMEvents: data.triggerGTMEvents,
+platform: 'tms-gtm',
 },
 true);
 

--- a/template.tpl
+++ b/template.tpl
@@ -179,7 +179,6 @@ ___TEMPLATE_PARAMETERS___
               "type": "SELECT",
               "name": "analytics_storage",
               "displayName": "Analytics storage",
-              "macrosInSelect": false,
               "selectItems": [
                 {
                   "value": "denied",
@@ -190,7 +189,8 @@ ___TEMPLATE_PARAMETERS___
                   "displayValue": "Granted"
                 }
               ],
-              "simpleValueType": true
+              "simpleValueType": true,
+              "defaultValue": "denied"
             },
             "isUnique": false
           },
@@ -199,7 +199,6 @@ ___TEMPLATE_PARAMETERS___
               "type": "SELECT",
               "name": "ad_storage",
               "displayName": "Ad storage",
-              "macrosInSelect": false,
               "selectItems": [
                 {
                   "value": "denied",
@@ -210,7 +209,8 @@ ___TEMPLATE_PARAMETERS___
                   "displayValue": "Granted"
                 }
               ],
-              "simpleValueType": true
+              "simpleValueType": true,
+              "defaultValue": "denied"
             },
             "isUnique": false
           },
@@ -219,7 +219,6 @@ ___TEMPLATE_PARAMETERS___
               "type": "SELECT",
               "name": "ad_user_data",
               "displayName": "Ad user data",
-              "macrosInSelect": false,
               "selectItems": [
                 {
                   "value": "denied",
@@ -230,7 +229,8 @@ ___TEMPLATE_PARAMETERS___
                   "displayValue": "Granted"
                 }
               ],
-              "simpleValueType": true
+              "simpleValueType": true,
+              "defaultValue": "denied"
             },
             "isUnique": false
           },
@@ -239,7 +239,6 @@ ___TEMPLATE_PARAMETERS___
               "type": "SELECT",
               "name": "ad_personalization",
               "displayName": "Ad personalization",
-              "macrosInSelect": false,
               "selectItems": [
                 {
                   "value": "denied",
@@ -250,7 +249,8 @@ ___TEMPLATE_PARAMETERS___
                   "displayValue": "Granted"
                 }
               ],
-              "simpleValueType": true
+              "simpleValueType": true,
+              "defaultValue": "denied"
             },
             "isUnique": false
           }

--- a/template.tpl
+++ b/template.tpl
@@ -10,9 +10,8 @@ ___INFO___
 
 {
   "type": "TAG",
-  "id": "cvt_temp_public_id",
+  "id": "cvt_5TPRD",
   "version": 1,
-  "securityGroups": [],
   "displayName": "Axeptio CMP",
   "brand": {
     "id": "github.com_axeptio",
@@ -22,7 +21,8 @@ ___INFO___
   "description": "Template for Axeptio cookie gestion",
   "containerContexts": [
     "WEB"
-  ]
+  ],
+  "securityGroups": []
 }
 
 
@@ -67,7 +67,7 @@ ___TEMPLATE_PARAMETERS___
         "name": "cookiesDuration",
         "displayName": "User cookies duration (in days)",
         "simpleValueType": true,
-        "defaultValue": 365,
+        "defaultValue": 180,
         "valueValidators": [
           {
             "type": "NON_NEGATIVE_NUMBER"

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,4 @@
-﻿___TERMS_OF_SERVICE___
+___TERMS_OF_SERVICE___
 
 By creating or modifying this file you agree to Google Tag Manager's Community
 Template Gallery Developer Terms of Service available at
@@ -333,7 +333,11 @@ ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 // Enter your template code here.
 const logToConsole = require('logToConsole');
 const setDefaultConsentState = require('setDefaultConsentState');
+const updateConsentState = require('updateConsentState');
 const gtagSet = require('gtagSet');
+const getCookieValues = require('getCookieValues');
+const JSON = require('JSON');
+const Object = require('Object');
 const queryPermission = require('queryPermission');
 const injectScript = require('injectScript');
 const setInWindow = require('setInWindow');
@@ -377,6 +381,28 @@ const main = (data) => {
     defaultData.wait_for_update = 500;
     setDefaultConsentState(defaultData);
   });
+
+  // Early consent update from Axeptio cookie (runs before SDK loads)
+  const cookieName = data.consentCookieName || ('axeptio_cookies_' + (data.id || ''));
+  if (cookieName) {
+    const cookieValues = getCookieValues(cookieName);
+    if (cookieValues && cookieValues.length > 0) {
+      const parsed = JSON.parse(cookieValues[0]);
+      if (parsed && parsed['$$completed'] && parsed['$$googleConsentMode'] && typeof parsed['$$googleConsentMode'] === 'object') {
+        const gcm = parsed['$$googleConsentMode'];
+        const consentModeStates = {};
+        for (const key in gcm) {
+          const val = gcm[key];
+          if (val === 'granted' || val === 'denied') {
+            consentModeStates[key] = val;
+          }
+        }
+        if (Object.keys(consentModeStates).length > 0) {
+          updateConsentState(consentModeStates);
+        }
+      }
+    }
+  }
 };
 
 main(data);


### PR DESCRIPTION
This new code:
- Requires `updateConsentState`, `getCookieValues`, `JSON`, and `Object` in addition to the existing utilities.
- Still calls `setDefaultConsentState` based on `defaultSettings` (as before).
- Adds an early consent update: reads the Axeptio cookie (`consentCookieName` or `axeptio_cookies_<projectId>`), parses `$$googleConsentMode`, filters values to `granted`/`denied`, and calls `updateConsentState` before the SDK loads.
- Leaves the Axeptio settings object, `setInWindow`, and script injection logic unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an early consent update that reads the Axeptio cookie and sets Google Consent Mode before the SDK loads. Also adds an “Additional Axeptio Settings” table and changes the default user cookie duration to 180 days.

- **New Features**
  - Early consent update: reads `consentCookieName` or `axeptio_cookies_<projectId>`, parses `$$googleConsentMode`, keeps only `granted/denied`, then calls `updateConsentState` before script injection.
  - New “Additional Axeptio Settings” table to extend `axeptioSettings`; entries are merged and exposed via `setInWindow`.
  - Sets `platform: 'tms-gtm'` in `axeptioSettings`.
  - Consent Mode fields default to `denied`; default cookie duration changed to 180 days.
  - README updated with clearer setup steps; docs link switched to https://support.axeptio.eu/en/.

- **Migration**
  - If you need the old 365-day cookie duration, set “User cookies duration” explicitly.
  - No config changes needed for early consent; it runs automatically when the Axeptio cookie is present.
  - Use the new table only if you want to pass advanced SDK options.

<sup>Written for commit 426a7c9e7c40badfae33d2715d4c5460ef4d50d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

